### PR TITLE
Add linter and standardized modules

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,192 @@
+# I don't like having arguments aligned for methods. I find it means your eyes have to jump around a lot more.
+Layout/ArgumentAlignment:
+  EnforcedStyle: with_fixed_indentation
+
+Layout/EmptyLinesAroundAttributeAccessor:
+  Enabled: True
+
+# As discussed with team in Slack
+Layout/DotPosition:
+  EnforcedStyle: leading
+
+# Nice to have a bit extra space before a trailing comment
+Layout/ExtraSpacing:
+  AllowBeforeTrailingComments: True
+
+Layout/FirstHashElementIndentation:
+  EnforcedStyle: consistent
+  
+Layout/IndentationWidth:
+  Width: 4
+
+Layout/LineLength:
+  Max: 120
+    
+Layout/MultilineMethodCallIndentation:
+  EnforcedStyle: indented
+
+Layout/SpaceAroundEqualsInParameterDefault:
+  Enabled: False
+
+Layout/SpaceAroundMethodCallOperator:
+  Enabled: True
+
+Lint/BinaryOperatorWithIdenticalOperands:
+  Enabled: True
+
+Lint/DeprecatedOpenSSLConstant:
+  Enabled: True
+
+Lint/DuplicateElsifCondition:
+  Enabled: True
+
+Lint/DuplicateRescueException:
+  Enabled: True
+
+Lint/EmptyConditionalBody:
+  Enabled: True
+
+Lint/FloatComparison:
+  Enabled: True
+
+Lint/MissingSuper:
+  Enabled: True
+
+Lint/MixedRegexpCaptureTypes:
+  Enabled: True
+
+Lint/OutOfRangeRegexpRef:
+  Enabled: True
+
+Lint/RaiseException:
+  Enabled: True
+
+Lint/SelfAssignment:
+  Enabled: True
+
+Lint/StructNewOverride:
+  Enabled: True
+
+Lint/TopLevelReturnWithArgument:
+  Enabled: True
+
+Lint/UnreachableLoop:
+  Enabled: True
+
+Metrics/BlockLength:
+  Exclude:
+    - 'spec/**/*'
+
+Metrics/ClassLength:
+  Enabled: true
+  Max: 350
+  Exclude:
+    - test/**/*
+
+
+Metrics/MethodLength:
+  Max: 60
+
+Style/AccessorGrouping:
+  Enabled: True
+
+Style/ArrayCoercion:
+  Enabled: False
+
+Style/BisectedAttrAccessor:
+  Enabled: True
+
+Style/BlockDelimiters:
+  Exclude:
+    - 'spec/**/*'
+
+Style/CaseLikeIf:
+  Enabled: False
+
+Style/EachWithObject:
+  Enabled: False
+
+Style/ExplicitBlockArgument:
+  Enabled: True
+
+Style/ExponentialNotation:
+  Enabled: True
+
+Style/FormatStringToken:
+  EnforcedStyle: template
+
+Style/FrozenStringLiteralComment:
+  Enabled: False
+
+Style/GlobalStdStream:
+  Enabled: True
+ 
+Style/GlobalVars:
+  Enabled: False
+
+Style/HashAsLastArrayItem:
+  Enabled: True
+
+Style/HashEachMethods:
+  Enabled: False
+
+Style/HashLikeCase:
+  Enabled: True
+
+Style/HashTransformKeys:
+  Enabled: False
+
+Style/HashTransformValues:
+  Enabled: False
+
+Style/NumericPredicate:
+  Enabled: False
+
+Style/OptionalBooleanParameter:
+  Enabled: True
+
+Style/RedundantAssignment:
+  Enabled: True
+
+Style/RedundantFetchBlock:
+  Enabled: True
+
+Style/RedundantFileExtensionInRequire:
+  Enabled: True
+
+Style/RedundantRegexpCharacterClass:
+  Enabled: False
+
+Style/RedundantRegexpEscape:
+  Enabled: False
+
+Style/SingleArgumentDig:
+  Enabled: False
+
+Style/SlicingWithRange:
+  Enabled: False
+
+Style/StringConcatenation:
+  Enabled: True
+
+Style/ZeroLengthPredicate:
+  Enabled: False
+
+Style/MultilineTernaryOperator :
+  Enabled: False
+
+Style/RegexpLiteral:
+  Enabled: False
+
+Style/TrailingCommaInArrayLiteral:
+  Enabled: False
+
+Style/TrailingCommaInHashLiteral:
+  Enabled: False
+
+# This one is too restrictive. E.g., 
+#     [['Mozart, Wolfgang Amadeus,', "a"], ["1756-1791", "d"]]
+#   reads better (and is easier to maintain, e.g., when making small changes) than
+#     [['Mozart, Wolfgang Amadeus,', "a"], %w[1756-1791 d]]
+Style/WordArray:
+  Enabled: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ before_install:
 install:
 - rake run_bundler
 script:
+- rake lint
 - rake test
 before_deploy:
 - rm -rf vendor

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,7 @@ deploy:
   - DB_USER=AQECAHjqALewp8JBJNxIQvR4oY795dyG7INaGR1glMsTEgetggAAAGcwZQYJKoZIhvcNAQcGoFgwVgIBADBRBgkqhkiG9w0BBwEwHgYJYIZIAWUDBAEuMBEEDODduMNijbjOeMwFjQIBEIAkt5GHQJEaAcShDYxOx1FY0AGEKIWu6yOpzhc2gzjp8gobPJUD
   - DB_QUERY='SELECT sierra_view.holding_record_card.id,sierra_view.holding_record_card.holding_record_id,sierra_view.bib_view.record_num,sierra_view.holding_record_box.* FROM sierra_view.holding_record_card LEFT OUTER JOIN sierra_view.bib_record_holding_record_link ON sierra_view.holding_record_card.holding_record_id=sierra_view.bib_record_holding_record_link.holding_record_id LEFT OUTER JOIN sierra_view.bib_view ON sierra_view.bib_view.id=sierra_view.bib_record_holding_record_link.bib_record_id LEFT OUTER JOIN sierra_view.holding_record_box ON sierra_view.holding_record_box.holding_record_cardlink_id=sierra_view.holding_record_card.id'
   - SQLITE_FILE=checkInCards.sql
+  - SQLITE_BUCKET=check-in-card-data-qa
   skip_cleanup: true
   access_key_id: "$AWS_ACCESS_KEY_ID_QA"
   secret_access_key: "$AWS_SECRET_ACCESS_KEY_QA"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,3 +6,4 @@
 - Added supporting documentation
 - Added unit test suite and basic travis integration
 - Added travis deployment and custom environment variable script
+- Added rubocop linter and standardized formatting

--- a/Gemfile
+++ b/Gemfile
@@ -1,11 +1,12 @@
 source 'https://rubygems.org'
 
-gem 'nypl_ruby_util'
 gem 'aws-sdk-s3'
+gem 'nypl_ruby_util'
 
 group :test do
-    gem 'rspec'
     gem 'mocha'
     gem 'pg'
+    gem 'rspec'
+    gem 'rubocop', require: false
     gem 'sqlite3'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,7 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    ast (2.4.1)
     avro (1.10.0)
       multi_json (~> 1)
     aws-eventstream (1.1.0)
@@ -34,7 +35,13 @@ GEM
       nypl_log_formatter (= 0.1.3)
       nypl_sierra_api_client (= 1.0.3)
     nypl_sierra_api_client (1.0.3)
+    parallel (1.19.2)
+    parser (2.7.1.4)
+      ast (~> 2.4.1)
     pg (1.2.3)
+    rainbow (3.0.0)
+    regexp_parser (1.7.1)
+    rexml (3.2.4)
     rspec (3.9.0)
       rspec-core (~> 3.9.0)
       rspec-expectations (~> 3.9.0)
@@ -48,7 +55,20 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.9.0)
     rspec-support (3.9.3)
+    rubocop (0.89.1)
+      parallel (~> 1.10)
+      parser (>= 2.7.1.1)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 1.7)
+      rexml
+      rubocop-ast (>= 0.3.0, < 1.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 1.4.0, < 2.0)
+    rubocop-ast (0.3.0)
+      parser (>= 2.7.1.4)
+    ruby-progressbar (1.10.1)
     sqlite3 (1.4.2)
+    unicode-display_width (1.7.0)
 
 PLATFORMS
   ruby
@@ -59,6 +79,7 @@ DEPENDENCIES
   nypl_ruby_util
   pg
   rspec
+  rubocop
   sqlite3
 
 BUNDLED WITH

--- a/lib/pg_manager.rb
+++ b/lib/pg_manager.rb
@@ -20,7 +20,7 @@ class PSQLClient
         begin
             @conn.exec query
         rescue StandardError => e
-            $logger.error 'Unable to query Sierra db for check-in rows', { message => e.message }
+            $logger.error 'Unable to query Sierra db for check-in rows', { message: e.message }
             raise PSQLError, 'Cannot execute query against Sierra db, no rows retrieved'
         end
     end

--- a/lib/pg_manager.rb
+++ b/lib/pg_manager.rb
@@ -1,6 +1,7 @@
 require 'pg'
 
-
+# Client for managing connections to the PostgreSQL database
+# Currently exposes a single method that allows executing an arbitraty query
 class PSQLClient
     def initialize
         @conn = PG.connect(
@@ -12,18 +13,17 @@ class PSQLClient
         )
     end
 
-    def exec_query query
-        $logger.info "Querying Sierra db for check-in boxes"
+    def exec_query(query)
+        $logger.info 'Querying Sierra db for check-in boxes'
         $logger.debug "Executing query: #{query}"
 
         begin
             @conn.exec query
-        rescue Exception => e
-            $logger.error "Unable to query Sierra db for check-in rows", { :message => e.message }
-            raise PSQLError.new "Cannot execute query against Sierra db, no rows retrieved"
+        rescue StandardError => e
+            $logger.error 'Unable to query Sierra db for check-in rows', { message => e.message }
+            raise PSQLError, 'Cannot execute query against Sierra db, no rows retrieved'
         end
     end
 end
-
 
 class PSQLError < StandardError; end

--- a/lib/s3_manager.rb
+++ b/lib/s3_manager.rb
@@ -16,9 +16,9 @@ class S3Client
         # Store file in s3
         begin
             @s3.put_object({
-                body => sql_data,
-                bucket => ENV['SQLITE_BUCKET'],
-                key => file,
+                body: sql_data,
+                bucket: ENV['SQLITE_BUCKET'],
+                key: file,
             })
         rescue StandardError => e
             $logger.error 'Unable to store sqlite db in s3', { status: e.message }

--- a/lib/s3_manager.rb
+++ b/lib/s3_manager.rb
@@ -18,7 +18,7 @@ class S3Client
         begin
             resp = @s3.put_object({
                 :body => sqlData,
-                :bucket => "check-in-card-data",
+                :bucket => ENV['SQLITE_BUCKET'],
                 :key => file,
             })
         rescue Exception => e

--- a/lib/s3_manager.rb
+++ b/lib/s3_manager.rb
@@ -1,32 +1,30 @@
 require 'aws-sdk-s3'
 
-
 # Class for managing the state of the poller in S3
 class S3Client
     # Create S3 client
     def initialize
-       @s3 = Aws::S3::Client.new(region: ENV['AWS_REGION'])
+        @s3 = Aws::S3::Client.new(region: ENV['AWS_REGION'])
     end
 
-    def store_data file
+    def store_data(file)
         $logger.info "Storing #{file} in s3 for retrieval by check-in card API"
 
         # Read file into memory
-        sqlData = File.read("/tmp/#{file}")
+        sql_data = File.read("/tmp/#{file}")
 
         # Store file in s3
         begin
-            resp = @s3.put_object({
-                :body => sqlData,
-                :bucket => ENV['SQLITE_BUCKET'],
-                :key => file,
+            @s3.put_object({
+                body => sql_data,
+                bucket => ENV['SQLITE_BUCKET'],
+                key => file,
             })
-        rescue Exception => e
-            $logger.error "Unable to store sqlite db in s3", { :status => e.message } 
-            raise S3Error "Unable to store sqlite db in s3"
+        rescue StandardError => e
+            $logger.error 'Unable to store sqlite db in s3', { status => e.message }
+            raise S3Error, 'Unable to store sqlite db in s3'
         end
     end
 end
-
 
 class S3Error < StandardError; end

--- a/lib/s3_manager.rb
+++ b/lib/s3_manager.rb
@@ -21,7 +21,7 @@ class S3Client
                 key => file,
             })
         rescue StandardError => e
-            $logger.error 'Unable to store sqlite db in s3', { status => e.message }
+            $logger.error 'Unable to store sqlite db in s3', { status: e.message }
             raise S3Error, 'Unable to store sqlite db in s3'
         end
     end

--- a/lib/sqlite_manager.rb
+++ b/lib/sqlite_manager.rb
@@ -1,13 +1,13 @@
 require 'sqlite3'
 
-
+# Client for creating and updating local sqlite3 database
 class SQLITEClient
     def initialize
         @db = SQLite3::Database.new "/tmp/#{ENV['SQLITE_FILE']}"
     end
 
     def create_table
-        $logger.info "Creating boxes table in sqlite database"
+        $logger.info 'Creating boxes table in sqlite database'
 
         @db.execute <<-BOXES
             create table boxes (
@@ -45,36 +45,35 @@ class SQLITEClient
         BOXES
     end
 
-    def insert_rows fields, rows
-       $logger.info "Inserting #{rows.length} rows into sqlite db" 
-        
-       insert_stmt = _generate_row_statements rows
+    def insert_rows(fields, rows)
+        $logger.info "Inserting #{rows.length} rows into sqlite db"
+
+        insert_stmt = _generate_row_statements rows
 
         begin
             @db.execute("INSERT INTO boxes (#{fields.join(', ')}) VALUES #{insert_stmt};")
-        rescue Exception => e
-            $logger.error "Unable to insert rows into boxes table", { "code" => e.code }
-            raise SqliteError.new "Failed to insert row into sqlite db"
+        rescue StandardError => e
+            $logger.error 'Unable to insert rows into boxes table', { 'code' => e.code }
+            raise SqliteError, 'Failed to insert row into sqlite db'
         end
     end
 
-    private 
+    private
 
-    def _generate_row_statements rows
-        insert_stmt = rows.map { |row|
+    def _generate_row_statements(rows)
+        rows.map do |row|
             $logger.debug "Inserting row# #{row[0]} into sqlite database"
             _prepare_row row
-        }.join(', ')
+        end.join(', ')
     end
 
-    def _prepare_row row
-        row_arr = row.map { |r|
+    def _prepare_row(row)
+        row_arr = row.map do |r|
             r ? "'#{r.gsub(/'/, "\\'")}'" : 'null'
-        }
+        end
 
-        return "(#{row_arr.join(', ')})"
+        "(#{row_arr.join(', ')})"
     end
 end
-
 
 class SqliteError < StandardError; end

--- a/lib/sqlite_manager.rb
+++ b/lib/sqlite_manager.rb
@@ -53,7 +53,7 @@ class SQLITEClient
         begin
             @db.execute("INSERT INTO boxes (#{fields.join(', ')}) VALUES #{insert_stmt};")
         rescue StandardError => e
-            $logger.error 'Unable to insert rows into boxes table', { 'code' => e.code }
+            $logger.error 'Unable to insert rows into boxes table', { code: e.code }
             raise SqliteError, 'Failed to insert row into sqlite db'
         end
     end

--- a/rakefile
+++ b/rakefile
@@ -1,34 +1,40 @@
 require 'yaml'
-# Basic utility commands to make working with SAM and AWS Lambda more friendly 
+# Basic utility commands to make working with SAM and AWS Lambda more friendly
 
-desc "Run test suite"
+desc 'Run test suite'
 task :test do
-    sh %{ rspec -fd }
+    sh %( rspec -fd )
 end
 
-desc "Run function locally. Accepts the name of the resource from the SAM config to select which function to invoke"
+desc 'Run function locally. Accepts the name of the resource from the SAM config to select which function to invoke'
 task :run_local do
-    sh %{ sam local invoke -t sam.local.yml --profile nypl-sandbox --region us-east-1 }
+    sh %( sam local invoke -t sam.local.yml --profile nypl-sandbox --region us-east-1 )
 end
 
-desc "Run bundler for local development and deployment"
+desc 'Run bundler for local development and deployment'
 task :run_bundler do
-    sh %{ bundle config unset deployment; bundle install; bundle config set deployment 'true'; bundle install }
+    sh %( bundle config unset deployment; bundle install; bundle config set deployment 'true'; bundle install )
 end
 
-desc "Run AWS environment config to set environment variables"
+desc 'Run AWS environment config to set environment variables'
 task :set_current_env_vars do
     if ENV['AWS_ACCESS_KEY_ID_QA'] && ENV['AWS_SECRET_ACCESS_KEY_QA']
-        sh %{ aws configure set aws_access_key_id #{ENV['AWS_ACCESS_KEY_ID_QA']} }
-        sh %{ aws configure set aws_secret_access_key #{ENV['AWS_SECRET_ACCESS_KEY_QA']} }
+        sh %( aws configure set aws_access_key_id #{ENV['AWS_ACCESS_KEY_ID_QA']} )
+        sh %( aws configure set aws_secret_access_key #{ENV['AWS_SECRET_ACCESS_KEY_QA']} )
     end
 
-    travis_conf = YAML.load(File.read('.travis.yml'))
+    travis_conf = YAML.safe_load(File.read('.travis.yml'))
     travis_conf['deploy'].each do |dep|
-        if dep[true]['branch'] == ENV['TRAVIS_BRANCH']
-            env_var_str = "Variables={#{dep['environment'].join(', ')}}"
-            sh %{ aws lambda update-function-configuration --function-name #{dep['function_name']} --environment "#{env_var_str}" --region us-east-1 }
-            break
-        end
+        break if dep[true]['branch'] == ENV['TRAVIS_BRANCH']
+
+        env_var_str = "Variables={#{dep['environment'].join(', ')}}"
+        # rubocop:disable Layout/LineLength
+        sh %( aws lambda update-function-configuration --function-name #{dep['function_name']} --environment "#{env_var_str}" --region us-east-1 )
+        # rubocop:enable Layout/LineLength
     end
+end
+
+desc 'Lint the application with the local rubocop settings'
+task :lint do
+    sh %( rubocop )
 end

--- a/sam.qa.yml
+++ b/sam.qa.yml
@@ -8,7 +8,7 @@ Globals:
       Runtime: ruby2.7
       Handler: app.handle_event
       Layers:
-        - arn:aws:lambda:us-east-1:224280085904:layer:ruby-pg-sqlite-lambda:2
+        - arn:aws:lambda:us-east-1:946183545209:layer:ruby-pg-sqlite-lambda:1
       Environment:
         Variables:
           LOG_LEVEL: debug
@@ -27,4 +27,4 @@ Resources:
             DB_PSWD: AQECAHjqALewp8JBJNxIQvR4oY795dyG7INaGR1glMsTEgetggAAAGwwagYJKoZIhvcNAQcGoF0wWwIBADBWBgkqhkiG9w0BBwEwHgYJYIZIAWUDBAEuMBEEDMd4YSniu1opPIHQpwIBEIApCgNpdccxBas9saGG1buhLcsMzGlVJqTBe15VSFk286b1kNJPoXmBKWs=
             DB_QUERY: 'SELECT sierra_view.holding_record_card.id,sierra_view.holding_record_card.holding_record_id,sierra_view.bib_view.record_num,sierra_view.holding_record_box.* FROM sierra_view.holding_record_card LEFT OUTER JOIN sierra_view.bib_record_holding_record_link ON sierra_view.holding_record_card.holding_record_id=sierra_view.bib_record_holding_record_link.holding_record_id LEFT OUTER JOIN sierra_view.bib_view ON sierra_view.bib_view.id=sierra_view.bib_record_holding_record_link.bib_record_id LEFT OUTER JOIN sierra_view.holding_record_box ON sierra_view.holding_record_box.holding_record_cardlink_id=sierra_view.holding_record_card.id LIMIT 60000'
             SQLITE_FILE: 'checkInCards.sql'
-            SQLITE_BUCKET: 'check-in-card-data-dev'
+            SQLITE_BUCKET: 'check-in-card-data-qa'

--- a/spec/handler_spec.rb
+++ b/spec/handler_spec.rb
@@ -1,28 +1,27 @@
 require_relative '../app'
 require_relative './spec_helper'
 
-
 describe 'handler' do
     describe :init do
-        before(:each) {
+        before(:each) do
             $initialized = false
 
-            @kms_mock = mock()
+            @kms_mock = mock
             @kms_mock.stubs(:decrypt)
             NYPLRubyUtil::KmsClient.stubs(:new).returns(@kms_mock)
-            @pg_mock = mock()
+            @pg_mock = mock
             PSQLClient.stubs(:new).returns(@pg_mock)
-            @sqlite_mock = mock()
+            @sqlite_mock = mock
             SQLITEClient.stubs(:new).returns(@sqlite_mock)
-            @s3_mock = mock()
+            @s3_mock = mock
             S3Client.stubs(:new).returns(@s3_mock)
-        }
+        end
 
-        after(:each) {
+        after(:each) do
             @kms_mock.unstub(:decrypt)
-        }
+        end
 
-        it "should invoke clients and logger from the ruby utils gem" do
+        it 'should invoke clients and logger from the ruby utils gem' do
             init
 
             expect($kms_client).to eq(@kms_mock)
@@ -31,21 +30,22 @@ describe 'handler' do
             expect($s3_client).to eq(@s3_mock)
             expect($initialized).to eq(true)
         end
-     end
+    end
 
     describe :handle_event do
-        before(:each) {
-            mock_sqlite = mock()
+        before(:each) do
+            mock_sqlite = mock
             $sqlite_client = mock_sqlite
 
-            mock_s3 = mock()
+            mock_s3 = mock
             $s3_client = mock_s3
-        }
-        it "should invoke validate_record and send_record_to_stream for each record" do
-            self.stubs(:init).once
+        end
+
+        it 'should invoke validate_record and send_record_to_stream for each record' do
+            stubs(:init).once
             $sqlite_client.stubs(:create_table).once
-            self.stubs(:fetch_rows).once.returns([1, 2, 3])
-            self.stubs(:store_rows).once.with([1, 2, 3])
+            stubs(:fetch_rows).once.returns([1, 2, 3])
+            stubs(:store_rows).once.with([1, 2, 3])
             $s3_client.stubs(:store_data).once.with('test.sql')
 
             handle_event(event: {}, context: {})
@@ -53,12 +53,12 @@ describe 'handler' do
     end
 
     describe :fetch_rows do
-        before(:each) {
-            mock_pg = mock()
+        before(:each) do
+            mock_pg = mock
             $pg_client = mock_pg
-        }
+        end
 
-        it "should execute a query against the postgres database" do
+        it 'should execute a query against the postgres database' do
             $pg_client.stubs(:exec_query).once.with('TEST QUERY')
 
             fetch_rows
@@ -66,24 +66,24 @@ describe 'handler' do
     end
 
     describe :store_rows do
-        before(:each) {
-            mock_sqlite = mock()
+        before(:each) do
+            mock_sqlite = mock
             $sqlite_client = mock_sqlite
-        }
+        end
 
-        it "should insert all rows in one batch if fewer than 100" do
+        it 'should insert all rows in one batch if fewer than 100' do
             row_arr = (0..99).to_a.map { |i| { 'id' => i } }
             $sqlite_client.stubs(:insert_rows).once.with(['id'], row_arr.map { |i| [i['id']] })
 
             store_rows row_arr
         end
 
-        it "should insert all rows in three batches if more than 200 and less than 300" do
+        it 'should insert all rows in three batches if more than 200 and less than 300' do
             row_arr = (0..250).to_a.map { |i| { 'id' => i } }
             $sqlite_client.stubs(:insert_rows).once.with(['id'], (0..99).to_a.map { |i| [i] })
             $sqlite_client.stubs(:insert_rows).once.with(['id'], (100..199).to_a.map { |i| [i] })
             $sqlite_client.stubs(:insert_rows).once.with(['id'], (200..250).to_a.map { |i| [i] })
-            
+
             store_rows row_arr
         end
     end

--- a/spec/pg_manager_spec.rb
+++ b/spec/pg_manager_spec.rb
@@ -1,14 +1,13 @@
 require_relative '../lib/pg_manager'
 require_relative './spec_helper'
 
-
 describe PSQLClient do
     describe :init do
-        before (:each) {
-            $kms_client = mock()
-        }
+        before(:each) do
+            $kms_client = mock
+        end
 
-        it "should create a connection object" do
+        it 'should create a connection object' do
             $kms_client.stubs(:decrypt).once.with('test_usr').returns('usr')
             $kms_client.stubs(:decrypt).once.with('test_pswd').returns('pswd')
 
@@ -23,17 +22,17 @@ describe PSQLClient do
     end
 
     describe :exec_query do
-        before (:each) {
-            @mock_conn = mock()
+        before(:each) do
+            @mock_conn = mock
             PG.stubs(:connect).returns(@mock_conn)
 
-            $kms_client = mock()
+            $kms_client = mock
             $kms_client.stubs(:decrypt)
 
             @test_client = PSQLClient.new
-        }
+        end
 
-        it "should execute a sql query and return the results if successful" do
+        it 'should execute a sql query and return the results if successful' do
             @mock_conn.stubs(:exec).once.with('test query').returns('test response')
 
             resp = @test_client.exec_query 'test query'
@@ -41,10 +40,12 @@ describe PSQLClient do
             expect(resp).to eq('test response')
         end
 
-        it "should raise a PSQLError if an exception occurs during the query" do
-            @mock_conn.stubs(:exec).once.raises(StandardError.new("Test db error"))
+        it 'should raise a PSQLError if an exception occurs during the query' do
+            @mock_conn.stubs(:exec).once.raises(StandardError.new('Test db error'))
 
-            expect { @test_client.send(:exec_query, 'test_query') }.to raise_error(PSQLError, "Cannot execute query against Sierra db, no rows retrieved")
+            expect {
+                @test_client.send(:exec_query, 'test_query')
+            }.to raise_error(PSQLError, 'Cannot execute query against Sierra db, no rows retrieved')
         end
     end
 end

--- a/spec/s3_manager_rspec.rb
+++ b/spec/s3_manager_rspec.rb
@@ -1,11 +1,10 @@
-require_relative "../lib/s3_manager"
-require_relative "./spec_helper"
-
+require_relative '../lib/s3_manager'
+require_relative './spec_helper'
 
 describe S3Client do
     describe :initialize do
-        it "should create a s3 client object" do
-            mock_client = mock()
+        it 'should create a s3 client object' do
+            mock_client = mock
             Aws::S3::Client.stubs(:new).once.with(region: 'test').returns(mock_client)
 
             test_client = S3Client.new
@@ -15,27 +14,29 @@ describe S3Client do
     end
 
     describe :store_data do
-        before (:each) {
-            Aws::S3::Client.stubs(:new).once.with(region: 'test').returns(mock())
+        before(:each) do
+            Aws::S3::Client.stubs(:new).once.with(region: 'test').returns(mock)
             @test_client = S3Client.new
 
             File.stubs(:read).returns('test_data')
-        }
-
-        it "should successfully call put_object and store the file" do
-            @test_client.instance_variable_get(:@s3).stubs(:put_object).once.with(
-                :body => 'test_data', :bucket => "test_bucket", :key => 'test_file'
-            )
-
-            @test_client.store_data "test_file"
         end
 
-        it "should raise an error if unable to store the file in s3" do
+        it 'should successfully call put_object and store the file' do
             @test_client.instance_variable_get(:@s3).stubs(:put_object).once.with(
-                :body => 'test_data', :bucket => "test_bucket", :key => 'test_file'
-            ).raises(StandardError.new("Unable to store sqlite db in s3"))
+                body => 'test_data', bucket => 'test_bucket', key => 'test_file'
+            )
 
-            expect { @test_client.send(:store_data, "test_file") }.to raise_error(S3Error, "Unable to store sqlite db in s3")
+            @test_client.store_data 'test_file'
+        end
+
+        it 'should raise an error if unable to store the file in s3' do
+            @test_client.instance_variable_get(:@s3).stubs(:put_object).once.with(
+                body => 'test_data', bucket => 'test_bucket', key => 'test_file'
+            ).raises(StandardError.new('Unable to store sqlite db in s3'))
+
+            expect {
+                @test_client.send(:store_data, 'test_file')
+            }.to raise_error(S3Error, 'Unable to store sqlite db in s3')
         end
     end
 end

--- a/spec/s3_manager_rspec.rb
+++ b/spec/s3_manager_rspec.rb
@@ -24,7 +24,7 @@ describe S3Client do
 
         it "should successfully call put_object and store the file" do
             @test_client.instance_variable_get(:@s3).stubs(:put_object).once.with(
-                :body => 'test_data', :bucket => "check-in-card-data", :key => 'test_file'
+                :body => 'test_data', :bucket => "test_bucket", :key => 'test_file'
             )
 
             @test_client.store_data "test_file"
@@ -32,7 +32,7 @@ describe S3Client do
 
         it "should raise an error if unable to store the file in s3" do
             @test_client.instance_variable_get(:@s3).stubs(:put_object).once.with(
-                :body => 'test_data', :bucket => "check-in-card-data", :key => 'test_file'
+                :body => 'test_data', :bucket => "test_bucket", :key => 'test_file'
             ).raises(StandardError.new("Unable to store sqlite db in s3"))
 
             expect { @test_client.send(:store_data, "test_file") }.to raise_error(S3Error, "Unable to store sqlite db in s3")

--- a/spec/s3_manager_rspec.rb
+++ b/spec/s3_manager_rspec.rb
@@ -23,7 +23,7 @@ describe S3Client do
 
         it 'should successfully call put_object and store the file' do
             @test_client.instance_variable_get(:@s3).stubs(:put_object).once.with(
-                body => 'test_data', bucket => 'test_bucket', key => 'test_file'
+                body: 'test_data', bucket: 'test_bucket', key: 'test_file'
             )
 
             @test_client.store_data 'test_file'
@@ -31,7 +31,7 @@ describe S3Client do
 
         it 'should raise an error if unable to store the file in s3' do
             @test_client.instance_variable_get(:@s3).stubs(:put_object).once.with(
-                body => 'test_data', bucket => 'test_bucket', key => 'test_file'
+                body: 'test_data', bucket: 'test_bucket', key: 'test_file'
             ).raises(StandardError.new('Unable to store sqlite db in s3'))
 
             expect {

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -26,82 +26,28 @@ ENV['AWS_REGION'] = 'test'
 ENV['SQLITE_BUCKET'] = 'test_bucket'
 
 RSpec.configure do |config|
-  # rspec-expectations config goes here. You can use an alternate
-  # assertion/expectation library such as wrong or the stdlib/minitest
-  # assertions if you prefer.
-  config.expect_with :rspec do |expectations|
-    # This option will default to `true` in RSpec 4. It makes the `description`
-    # and `failure_message` of custom matchers include text for helper methods
-    # defined using `chain`, e.g.:
-    #     be_bigger_than(2).and_smaller_than(4).description
-    #     # => "be bigger than 2 and smaller than 4"
-    # ...rather than:
-    #     # => "be bigger than 2"
-    expectations.include_chain_clauses_in_custom_matcher_descriptions = true
-  end
+    # rspec-expectations config goes here. You can use an alternate
+    # assertion/expectation library such as wrong or the stdlib/minitest
+    # assertions if you prefer.
+    config.expect_with :rspec do |expectations|
+        # This option will default to `true` in RSpec 4. It makes the `description`
+        # and `failure_message` of custom matchers include text for helper methods
+        # defined using `chain`, e.g.:
+        #     be_bigger_than(2).and_smaller_than(4).description
+        #     # => "be bigger than 2 and smaller than 4"
+        # ...rather than:
+        #     # => "be bigger than 2"
+        expectations.include_chain_clauses_in_custom_matcher_descriptions = true
+    end
 
-  # rspec-mocks config goes here. You can use an alternate test double
-  # library (such as bogus or mocha) by changing the `mock_with` option here.
-  config.mock_with :mocha
+    # rspec-mocks config goes here. You can use an alternate test double
+    # library (such as bogus or mocha) by changing the `mock_with` option here.
+    config.mock_with :mocha
 
-  # This option will default to `:apply_to_host_groups` in RSpec 4 (and will
-  # have no way to turn it off -- the option exists only for backwards
-  # compatibility in RSpec 3). It causes shared context metadata to be
-  # inherited by the metadata hash of host groups and examples, rather than
-  # triggering implicit auto-inclusion in groups with matching metadata.
-  config.shared_context_metadata_behavior = :apply_to_host_groups
-
-# The settings below are suggested to provide a good initial experience
-# with RSpec, but feel free to customize to your heart's content.
-=begin
-  # This allows you to limit a spec run to individual examples or groups
-  # you care about by tagging them with `:focus` metadata. When nothing
-  # is tagged with `:focus`, all examples get run. RSpec also provides
-  # aliases for `it`, `describe`, and `context` that include `:focus`
-  # metadata: `fit`, `fdescribe` and `fcontext`, respectively.
-  config.filter_run_when_matching :focus
-
-  # Allows RSpec to persist some state between runs in order to support
-  # the `--only-failures` and `--next-failure` CLI options. We recommend
-  # you configure your source control system to ignore this file.
-  config.example_status_persistence_file_path = "spec/examples.txt"
-
-  # Limits the available syntax to the non-monkey patched syntax that is
-  # recommended. For more details, see:
-  #   - http://rspec.info/blog/2012/06/rspecs-new-expectation-syntax/
-  #   - http://www.teaisaweso.me/blog/2013/05/27/rspecs-new-message-expectation-syntax/
-  #   - http://rspec.info/blog/2014/05/notable-changes-in-rspec-3/#zero-monkey-patching-mode
-  config.disable_monkey_patching!
-
-  # This setting enables warnings. It's recommended, but in some cases may
-  # be too noisy due to issues in dependencies.
-  config.warnings = true
-
-  # Many RSpec users commonly either run the entire suite or an individual
-  # file, and it's useful to allow more verbose output when running an
-  # individual spec file.
-  if config.files_to_run.one?
-    # Use the documentation formatter for detailed output,
-    # unless a formatter has already been configured
-    # (e.g. via a command-line flag).
-    config.default_formatter = "doc"
-  end
-
-  # Print the 10 slowest examples and example groups at the
-  # end of the spec run, to help surface which specs are running
-  # particularly slow.
-  config.profile_examples = 10
-
-  # Run specs in random order to surface order dependencies. If you find an
-  # order dependency and want to debug it, you can fix the order by providing
-  # the seed, which is printed after each run.
-  #     --seed 1234
-  config.order = :random
-
-  # Seed global randomization in this process using the `--seed` CLI option.
-  # Setting this allows you to use `--seed` to deterministically reproduce
-  # test failures related to randomization by passing the same `--seed` value
-  # as the one that triggered the failure.
-  Kernel.srand config.seed
-=end
+    # This option will default to `:apply_to_host_groups` in RSpec 4 (and will
+    # have no way to turn it off -- the option exists only for backwards
+    # compatibility in RSpec 3). It causes shared context metadata to be
+    # inherited by the metadata hash of host groups and examples, rather than
+    # triggering implicit auto-inclusion in groups with matching metadata.
+    config.shared_context_metadata_behavior = :apply_to_host_groups
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -23,6 +23,7 @@ ENV['DB_NAME'] = 'test_db'
 ENV['DB_USER'] = 'test_usr'
 ENV['DB_PSWD'] = 'test_pswd'
 ENV['AWS_REGION'] = 'test'
+ENV['SQLITE_BUCKET'] = 'test_bucket'
 
 RSpec.configure do |config|
   # rspec-expectations config goes here. You can use an alternate

--- a/spec/sqlite_manager_spec.rb
+++ b/spec/sqlite_manager_spec.rb
@@ -1,10 +1,9 @@
 require_relative '../lib/sqlite_manager'
 require_relative './spec_helper'
 
-
 describe SQLITEClient do
     describe :initialize do
-        it "should initialize a database in the /tmp directory" do
+        it 'should initialize a database in the /tmp directory' do
             SQLite3::Database.stubs(:new).once.with('/tmp/test.sql').returns('test_db')
             test_client = SQLITEClient.new
 
@@ -13,12 +12,12 @@ describe SQLITEClient do
     end
 
     describe :create_table do
-        before (:each) {
-            SQLite3::Database.stubs(:new).once.with('/tmp/test.sql').returns(mock())
+        before(:each) {
+            SQLite3::Database.stubs(:new).once.with('/tmp/test.sql').returns(mock)
             @test_client = SQLITEClient.new
         }
 
-        it "should execute a query to create the boxes table" do
+        it 'should execute a query to create the boxes table' do
             @test_client.instance_variable_get(:@db).stubs(:execute).once
 
             @test_client.create_table
@@ -26,12 +25,12 @@ describe SQLITEClient do
     end
 
     describe :insert_rows do
-        before (:each) {
-            SQLite3::Database.stubs(:new).once.with('/tmp/test.sql').returns(mock())
+        before(:each) {
+            SQLite3::Database.stubs(:new).once.with('/tmp/test.sql').returns(mock)
             @test_client = SQLITEClient.new
         }
 
-        it "should execute insert statement for all rows" do
+        it 'should execute insert statement for all rows' do
             @test_client.instance_variable_get(:@db).stubs(:execute).once.with(
                 "INSERT INTO boxes (id) VALUES ('1'), ('2'), ('3');"
             )
@@ -42,7 +41,7 @@ describe SQLITEClient do
             @test_client.insert_rows(['id'], [1, 2, 3])
         end
 
-        it "should raise an exception if it is unable to insert the rows" do
+        it 'should raise an exception if it is unable to insert the rows' do
             @test_client.instance_variable_get(:@db).stubs(:execute).once.with(
                 "INSERT INTO boxes (id) VALUES ('1'), ('2'), ('3');"
             ).raises(SQLite3::Exception.new('test error'))
@@ -50,17 +49,19 @@ describe SQLITEClient do
                 "('1'), ('2'), ('3')"
             )
 
-            expect { @test_client.send(:insert_rows, ['id'], [1, 2, 3])}.to raise_error(SqliteError, "Failed to insert row into sqlite db")
+            expect {
+                @test_client.send(:insert_rows, ['id'], [1, 2, 3])
+            }.to raise_error(SqliteError, 'Failed to insert row into sqlite db')
         end
     end
 
     describe :_generate_row_statements do
-        before (:each) {
-            SQLite3::Database.stubs(:new).once.with('/tmp/test.sql').returns(mock())
+        before(:each) {
+            SQLite3::Database.stubs(:new).once.with('/tmp/test.sql').returns(mock)
             @test_client = SQLITEClient.new
         }
 
-        it "should create an array of entries from the rows argument" do
+        it 'should create an array of entries from the rows argument' do
             @test_client.stubs(:_prepare_row).once.with(1).returns("('1')")
             @test_client.stubs(:_prepare_row).once.with(2).returns("('2')")
             @test_client.stubs(:_prepare_row).once.with(3).returns("('3')")
@@ -71,18 +72,18 @@ describe SQLITEClient do
     end
 
     describe :_prepare_row do
-        before (:each) {
-            SQLite3::Database.stubs(:new).once.with('/tmp/test.sql').returns(mock())
+        before(:each) {
+            SQLite3::Database.stubs(:new).once.with('/tmp/test.sql').returns(mock)
             @test_client = SQLITEClient.new
         }
 
-        it "should quote all values passed in" do
+        it 'should quote all values passed in' do
             test_row = @test_client.send(:_prepare_row, ['1', 'test', 'value'])
 
             expect(test_row).to eq("('1', 'test', 'value')")
         end
 
-        it "should replate nil values with unquoted null values" do
+        it 'should replate nil values with unquoted null values' do
             test_row = @test_client.send(:_prepare_row, ['1', nil, '2', nil])
 
             expect(test_row).to eq("('1', null, '2', null)")


### PR DESCRIPTION
This implements rubocop as a linter and includes the linted updates for all of the files. As this was the first time applying these standards there are numerous changes, but it should be the first step towards standardizing ruby/lambda development.