### PR TITLE
SCC-2204 batched performance improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,8 +21,11 @@ deploy:
   role: arn:aws:iam::946183545209:role/lambda-full-access
   runtime: ruby2.7
   timeout: 300
+  memory_size: 256
   module_name: app
   handler_name: handle_event
+  layers:
+  - arn:aws:lambda:us-east-1:946183545209:layer:ruby-pg-sqlite-lambda:2
   environment:
   - LOG_LEVEL=info
   - DB_HOST=10.146.200.10
@@ -30,7 +33,7 @@ deploy:
   - DB_PSWD=AQECAHh7ea2tyZ6phZgT4B9BDKwguhlFtRC6hgt+7HbmeFsrsgAAAGwwagYJKoZIhvcNAQcGoF0wWwIBADBWBgkqhkiG9w0BBwEwHgYJYIZIAWUDBAEuMBEEDDnjoRlSmwePv1QxSwIBEIAplnBJKYjr0qYPnQ3GIZ3yDzbf3i0Aa5q+dLB07MRFxbF6Rok1MKeCwZ8=
   - DB_USER=AQECAHh7ea2tyZ6phZgT4B9BDKwguhlFtRC6hgt+7HbmeFsrsgAAAGcwZQYJKoZIhvcNAQcGoFgwVgIBADBRBgkqhkiG9w0BBwEwHgYJYIZIAWUDBAEuMBEEDNapmZKmWxO59lrUhAIBEIAkPcsXj35Is8+naFzWIsWYMa9Yvt+aJZqfFZgDicQSnmEUAWBr
   - DB_NAME=iii
-  - DB_QUERY='SELECT sierra_view.holding_record_card.id,sierra_view.holding_record_card.holding_record_id,sierra_view.bib_view.record_num,sierra_view.holding_record_box.* FROM sierra_view.holding_record_card LEFT OUTER JOIN sierra_view.bib_record_holding_record_link ON sierra_view.holding_record_card.holding_record_id=sierra_view.bib_record_holding_record_link.holding_record_id LEFT OUTER JOIN sierra_view.bib_view ON sierra_view.bib_view.id=sierra_view.bib_record_holding_record_link.bib_record_id LEFT OUTER JOIN sierra_view.holding_record_box ON sierra_view.holding_record_box.holding_record_cardlink_id=sierra_view.holding_record_card.id'
+  - DB_QUERY='SELECT sierra_view.holding_record_card.id, sierra_view.holding_record_card.holding_record_id, sierra_view.holding_view.record_num, sierra_view.holding_record_box.* FROM sierra_view.holding_record_card LEFT OUTER JOIN sierra_view.holding_view ON sierra_view.holding_view.id=sierra_view.holding_record_card.holding_record_id LEFT OUTER JOIN sierra_view.holding_record_cardlink ON sierra_view.holding_record_card.id=sierra_view.holding_record_cardlink.holding_record_card_id LEFT OUTER JOIN sierra_view.holding_record_box ON sierra_view.holding_record_box.holding_record_cardlink_id=sierra_view.holding_record_cardlink.id'
   - SQLITE_FILE=checkInCards.sql
   - SQLITE_BUCKET=check-in-card-data-qa
   skip_cleanup: true

--- a/app.rb
+++ b/app.rb
@@ -39,7 +39,7 @@ def fetch_and_store_rows
     limit = 100_000
     loop do
         $logger.info "Querying sierra for record batch #{offset}:#{limit}"
-        box_rows = $pg_client.exec_query(ENV['DB_QUERY'], offset, limit)
+        box_rows = $pg_client.exec_query(ENV['DB_QUERY'], offset: offset, limit: limit)
 
         break unless box_rows.ntuples > 0
 

--- a/lib/pg_manager.rb
+++ b/lib/pg_manager.rb
@@ -13,7 +13,7 @@ class PSQLClient
         )
     end
 
-    def exec_query(query, offset = nil, limit = nil)
+    def exec_query(query, offset: nil, limit: nil)
         $logger.info 'Querying Sierra db for check-in boxes'
         $logger.debug "Executing query: #{query}"
 

--- a/lib/pg_manager.rb
+++ b/lib/pg_manager.rb
@@ -13,9 +13,12 @@ class PSQLClient
         )
     end
 
-    def exec_query(query)
+    def exec_query(query, offset = nil, limit = nil)
         $logger.info 'Querying Sierra db for check-in boxes'
         $logger.debug "Executing query: #{query}"
+
+        query = "#{query} OFFSET #{offset}" if offset
+        query = "#{query} LIMIT #{limit}" if limit
 
         begin
             @conn.exec query

--- a/lib/sqlite_manager.rb
+++ b/lib/sqlite_manager.rb
@@ -65,7 +65,7 @@ class SQLITEClient
 
     def _generate_row_statements(rows)
         rows.map do |row|
-            next if row[0] == nil
+            next if row[0].nil?
 
             $logger.debug "Inserting row# #{row[0]} into sqlite database"
             _prepare_row row

--- a/lib/sqlite_manager.rb
+++ b/lib/sqlite_manager.rb
@@ -34,13 +34,13 @@ class SQLITEClient
                 chron_level_k_trans_date int,
                 chron_level_l_trans_date int,
                 chron_level_m_trans_date int,
-                note varchar(250),
+                note varchar(500),
                 box_status_code char(1),
                 claim_cnt int,
                 copies_cnt int,
-                url varchar(250),
+                url varchar(500),
                 is_suppressed bool,
-                staff_note varchar(250)
+                staff_note varchar(500)
             );
         BOXES
     end
@@ -50,9 +50,12 @@ class SQLITEClient
 
         insert_stmt = _generate_row_statements rows
 
+        return if insert_stmt.length == 0
+
         begin
             @db.execute("INSERT INTO boxes (#{fields.join(', ')}) VALUES #{insert_stmt};")
         rescue StandardError => e
+            $logger.debug insert_stmt
             $logger.error 'Unable to insert rows into boxes table', { code: e.code }
             raise SqliteError, 'Failed to insert row into sqlite db'
         end
@@ -62,14 +65,16 @@ class SQLITEClient
 
     def _generate_row_statements(rows)
         rows.map do |row|
+            next if row[0] == nil
+
             $logger.debug "Inserting row# #{row[0]} into sqlite database"
             _prepare_row row
-        end.join(', ')
+        end.compact.join(', ')
     end
 
     def _prepare_row(row)
         row_arr = row.map do |r|
-            r ? "'#{r.gsub(/'/, "\\'")}'" : 'null'
+            r ? "'#{r.gsub(/'/, "''")}'" : 'null'
         end
 
         "(#{row_arr.join(', ')})"

--- a/sam.local.yml
+++ b/sam.local.yml
@@ -4,7 +4,8 @@ Description: Function for fetching updates to check-in cards from the previous c
 
 Globals:
     Function:
-      Timeout: 300
+      Timeout: 600
+      MemorySize: 256
       Runtime: ruby2.7
       Handler: app.handle_event
       Layers:
@@ -27,4 +28,4 @@ Resources:
             DB_PSWD: AQECAHjqALewp8JBJNxIQvR4oY795dyG7INaGR1glMsTEgetggAAAGwwagYJKoZIhvcNAQcGoF0wWwIBADBWBgkqhkiG9w0BBwEwHgYJYIZIAWUDBAEuMBEEDMd4YSniu1opPIHQpwIBEIApCgNpdccxBas9saGG1buhLcsMzGlVJqTBe15VSFk286b1kNJPoXmBKWs=
             DB_QUERY: 'SELECT sierra_view.holding_record_card.id, sierra_view.holding_record_card.holding_record_id, sierra_view.holding_view.record_num, sierra_view.holding_record_box.* FROM sierra_view.holding_record_card LEFT OUTER JOIN sierra_view.holding_view ON sierra_view.holding_view.id=sierra_view.holding_record_card.holding_record_id LEFT OUTER JOIN sierra_view.holding_record_cardlink ON sierra_view.holding_record_card.id=sierra_view.holding_record_cardlink.holding_record_card_id LEFT OUTER JOIN sierra_view.holding_record_box ON sierra_view.holding_record_box.holding_record_cardlink_id=sierra_view.holding_record_cardlink.id'
             SQLITE_FILE: 'checkInCards.sql'
-            SQLITE_BUCKET: 'check-in-card-data-dev'
+            SQLITE_BUCKET: 'check-in-card-data'

--- a/sam.qa.yml
+++ b/sam.qa.yml
@@ -4,7 +4,8 @@ Description: Function for fetching updates to check-in cards from the previous c
 
 Globals:
     Function:
-      Timeout: 300
+      Timeout: 600
+      MemorySize: 256
       Runtime: ruby2.7
       Handler: app.handle_event
       Layers:

--- a/spec/pg_manager_spec.rb
+++ b/spec/pg_manager_spec.rb
@@ -40,6 +40,22 @@ describe PSQLClient do
             expect(resp).to eq('test response')
         end
 
+        it 'should execute a sql query with offset/limit if provided' do
+            @mock_conn.stubs(:exec).once.with('test query OFFSET 10 LIMIT 1').returns('test response')
+
+            resp = @test_client.exec_query('test query', offset: 10, limit: 1)
+
+            expect(resp).to eq('test response')
+        end
+
+        it 'should execute a sql query with only limit if provided and offset is nil' do
+            @mock_conn.stubs(:exec).once.with('test query LIMIT 1').returns('test response')
+
+            resp = @test_client.exec_query('test query', limit: 1)
+
+            expect(resp).to eq('test response')
+        end
+
         it 'should raise a PSQLError if an exception occurs during the query' do
             @mock_conn.stubs(:exec).once.raises(StandardError.new('Test db error'))
 

--- a/spec/sqlite_manager_spec.rb
+++ b/spec/sqlite_manager_spec.rb
@@ -41,6 +41,13 @@ describe SQLITEClient do
             @test_client.insert_rows(['id'], [1, 2, 3])
         end
 
+        it 'should skip execution if no valid rows were received' do
+            @test_client.stubs(:_generate_row_statements).once.with([1, 2, 3]).returns('')
+            @test_client.instance_variable_get(:@db).stubs(:execute).never
+
+            @test_client.insert_rows(['id'], [1, 2, 3])
+        end
+
         it 'should raise an exception if it is unable to insert the rows' do
             @test_client.instance_variable_get(:@db).stubs(:execute).once.with(
                 "INSERT INTO boxes (id) VALUES ('1'), ('2'), ('3');"


### PR DESCRIPTION
This improves the performance of the check-in card poller by limiting the number of records retrieved in a single request. Occasional timeouts were being received and this resolves that by ensuring that the requests are always of a reasonable size. This involved a slight reorganization of the logic and updating some configuration