### PR TITLE
NOREF Ignore Duplicate rows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 0.0.2 - 2020-10-09
+### Fixed
+- Added UNIQUE constraint to SQLITE database and ensure that duplicate rows are ignored
+
 ## 0.0.1 - 2020-09-17
 ### Added
 - Initial commit containing Sierra database poller and sqlite database writer

--- a/lib/sqlite_manager.rb
+++ b/lib/sqlite_manager.rb
@@ -11,7 +11,7 @@ class SQLITEClient
 
         @db.execute <<-BOXES
             create table boxes (
-                id int,
+                id int UNIQUE,
                 holding_record_id int,
                 record_num int,
                 holding_record_cardlink_id int,
@@ -53,7 +53,7 @@ class SQLITEClient
         return if insert_stmt.length == 0
 
         begin
-            @db.execute("INSERT INTO boxes (#{fields.join(', ')}) VALUES #{insert_stmt};")
+            @db.execute("INSERT OR IGNORE INTO boxes (#{fields.join(', ')}) VALUES #{insert_stmt};")
         rescue StandardError => e
             $logger.debug insert_stmt
             $logger.error 'Unable to insert rows into boxes table', { code: e.code }

--- a/spec/sqlite_manager_spec.rb
+++ b/spec/sqlite_manager_spec.rb
@@ -32,7 +32,7 @@ describe SQLITEClient do
 
         it 'should execute insert statement for all rows' do
             @test_client.instance_variable_get(:@db).stubs(:execute).once.with(
-                "INSERT INTO boxes (id) VALUES ('1'), ('2'), ('3');"
+                "INSERT OR IGNORE INTO boxes (id) VALUES ('1'), ('2'), ('3');"
             )
             @test_client.stubs(:_generate_row_statements).once.with([1, 2, 3]).returns(
                 "('1'), ('2'), ('3')"
@@ -50,7 +50,7 @@ describe SQLITEClient do
 
         it 'should raise an exception if it is unable to insert the rows' do
             @test_client.instance_variable_get(:@db).stubs(:execute).once.with(
-                "INSERT INTO boxes (id) VALUES ('1'), ('2'), ('3');"
+                "INSERT OR IGNORE INTO boxes (id) VALUES ('1'), ('2'), ('3');"
             ).raises(SQLite3::Exception.new('test error'))
             @test_client.stubs(:_generate_row_statements).once.with([1, 2, 3]).returns(
                 "('1'), ('2'), ('3')"


### PR DESCRIPTION
For not fully understood reasons the current process can produce duplicate rows in the SQLITE database. This implements a `UNIQUE` constraint on the `id` column to ensure that each row is distinct and adds an `OR IGNORE` clause to the `INSERT` query to quietly skip any rows that violate that constraint.